### PR TITLE
feat: add scheduled tasks and upcoming view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -727,3 +727,33 @@ Added Everforest to the built-in themes palette.
 - **Palette**: Warm, earthy forest ground (`Bg: #272e33`, `PaneBg: #2d353b`, `Panel: #343f44`, `Border: #475258`) paired with signature sage green (`Accent: #a7c080`, `BorderFocus: #a7c080`), warm cream text (`#d3c6aa`), muted grey-green (`#7a8478`), warm yellow (`Warning: #dbbc7f`), soft red (`Danger: #e67e80`), and soft purple (`Purple: #d699b6`).
 - **Surface layering & contrast**: Respects the `Bg < PaneBg < Panel < Border` luminance hierarchy. High contrast on headers (`AppTitleFg: #272e33` on `#a7c080` gives 6.88:1), crisp text readability (7.38:1 on pane bg), and a strictly monotonic 5-step heatmap ramp (`#343f44`, `#3d5248`, `#516f58`, `#78a06f`, `#a7c080`).
 
+## Scheduled tasks (2026-09-03)
+
+Branch `feat/schedule-tasks` starts at `upstream/main` (`85d8699`), independently
+of task editing. Architecture review confirmed that `Task.Date` already owns
+the scheduled day, Today selects equality with the local date, and Overdue
+selects unfinished earlier dates. No model or JSON migration is needed.
+
+- A pure `parseTaskInput` helper accepts `title [MM-DD] [HH:MM]`, preserving
+  the legacy time-only syntax and internal title whitespace. Date-only input
+  is a task; a valid trailing time makes an appointment. Dates choose the next
+  valid occurrence including today; February 29 can advance to a later leap
+  year. Invalid calendar dates retain the input and show a validation error.
+- `Shift+C` switches the Today pane to Upcoming, sorted by date, time, and
+  creation time. The Notes binding still clears the board. Simple mode also
+  supports Upcoming; its current combined list is restored on return.
+- Upcoming rows show the full scheduled date through the shared row renderer.
+  Adding selects the corresponding current/future view and the new task ID.
+  Important/undone filters apply to Upcoming; simple mode now supports them too.
+- Tick and resize handling clamp selections and scroll offsets. Delete
+  confirmations retain the item identity and cancel if a date rollover
+  changed the selected item, including notes in the simple combined list.
+- Parser and view work were delegated independently, then integrated. Added
+  tests cover parsing, leap years, local-date boundaries, list transitions,
+  selection/actions, rendering dimensions, persistence, and report boundaries.
+  README documents the syntax, year resolution, and contextual C binding.
+
+Validation limitation: Go is unavailable in this environment, and downloading
+the toolchain was blocked by network access. The Go tests, build, vet, and
+gofmt must still be run in a Go 1.26.3 environment. Static review and
+`git diff --check` were performed; these do not substitute for executable tests.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ taskii --simple   # single-pane view: greeting + one combined list of tasks, ove
 | `i` | toggle important |
 | `I` | filter: important only |
 | `U` | filter: undone only |
+| `C` (outside Notes) | switch Today / Upcoming; current list / Upcoming in simple mode |
 | `e` | expand/collapse the notes board |
 | `C` | clear all notes (asks to confirm) |
 | `p` | start/pause Pomodoro |
@@ -85,9 +86,39 @@ taskii --simple   # single-pane view: greeting + one combined list of tasks, ove
 
 On the Reports pane, `←/→` (or `h/l`) switch between the Week, Month, and Contribution charts instead of moving a selection.
 
+## Scheduled tasks
+
+Press `a` in the task pane and append a date, a time, or both:
+
+| Input | Result |
+| --- | --- |
+| `Read a chapter` | Task for today |
+| `Call Alex 14:30` | Appointment for today at 14:30 |
+| `Read a chapter 09-10` | Task for September 10 |
+| `Call Alex 09-10 14:30` | Appointment for September 10 at 14:30 |
+
+Dates use `MM-DD` and times use `HH:MM` (24-hour clock). The date is the next
+occurrence of that month and day, including today. A date that has already
+passed rolls forward to next year; `02-29` selects the next valid leap day.
+Impossible dates, such as `02-30`, show an error and keep the input for correction.
+Date and time tokens must be at the end of the title, in that order when both
+are present. A trailing `MM-DD` token is interpreted as a schedule date.
+
+`Shift+C` opens **Upcoming**, sorted by date and then appointment time, with
+untimed tasks after appointments on the same day. Each row shows its full date.
+Press it again to return to Today (or the current combined list in `--simple`).
+On the Notes pane, `Shift+C` retains its existing clear-board action.
+Adding a task switches to the view containing its date.
+
+Scheduled tasks automatically appear in Today on their date. Unfinished tasks
+from earlier dates appear in Overdue using the existing behavior. These lists
+refresh while the app is running; no restart or rescheduling is needed.
+The saved JSON format is unchanged: the scheduled day is stored in `Task.Date`.
+
 ## Features
 
 - **Today / Overdue** — add tasks or timed appointments (type a trailing `14:30` to mark one as an appointment), toggle done, mark important, delete.
+- **Upcoming** — schedule tasks with a trailing `MM-DD`, optionally followed by `HH:MM`, and browse future dates with `Shift+C`.
 - **Notes** — a simple multi-line notes board, expandable to full screen.
 - **Pomodoro timer** — start, pause, reset, and skip work/break phases.
 - **Reports** — completion progress, a 7-day/monthly bar chart, and a contribution heatmap.
@@ -97,6 +128,7 @@ On the Reports pane, `←/→` (or `h/l`) switch between the Week, Month, and Co
 ## Development
 
 ```bash
+go test ./...    # tests
 go build ./...   # build
 go vet ./...     # static checks
 gofmt -l .       # formatting check

--- a/internal/stats/schedule_test.go
+++ b/internal/stats/schedule_test.go
@@ -1,0 +1,41 @@
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"taskii/internal/model"
+)
+
+func TestScheduledTasksEnterReportsOnTheirDate(t *testing.T) {
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	tasks := []model.Task{
+		{Date: "2026-09-03", Done: true},
+		{Date: "2026-09-04"},
+		{Date: "2026-09-04", Done: true},
+	}
+
+	before := Compute(tasks, now)
+	for name, progress := range map[string]Progress{
+		"today": before.Today, "week": before.Week, "month": before.Month,
+	} {
+		if progress != (Progress{Done: 1, Total: 1}) {
+			t.Errorf("%s includes future tasks: %+v", name, progress)
+		}
+	}
+	for _, bars := range [][]DayBar{before.WeekBars, before.MonthBars} {
+		for _, bar := range bars {
+			if bar.Date.Format(dateFormat) > "2026-09-03" {
+				t.Errorf("future date included in reports: %v", bar.Date)
+			}
+		}
+	}
+
+	after := Compute(tasks, now.AddDate(0, 0, 1))
+	if after.Today != (Progress{Done: 1, Total: 2}) {
+		t.Errorf("scheduled tasks missing on their date: %+v", after.Today)
+	}
+	if after.Week != (Progress{Done: 2, Total: 3}) || after.Month != after.Week {
+		t.Errorf("wrong totals after scheduled date: week=%+v month=%+v", after.Week, after.Month)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -49,6 +49,7 @@ type App struct {
 	focus focusedPane
 	mode  mode
 
+	upcoming      bool // the Today pane is currently showing future tasks
 	todaySelected int
 	todayScroll   int
 
@@ -81,10 +82,11 @@ type App struct {
 	simpleScroll   int
 	simpleNoteMode bool
 
-	input     textinput.Model
-	err       string
-	status    string
-	noPersist bool
+	input        textinput.Model
+	err          string
+	status       string
+	noPersist    bool
+	deleteItemID string // task/note shown when the delete confirmation opened
 
 	username string
 	layout   layout
@@ -152,7 +154,7 @@ func NewApp(opts Options) App {
 	}
 
 	ti := textinput.New()
-	ti.Placeholder = "Title, or end with HH:MM to add it as an appointment"
+	ti.Placeholder = "Title [MM-DD] [HH:MM]"
 	ti.CharLimit = 120
 
 	ta := textarea.New()
@@ -192,9 +194,12 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		a.width = msg.Width
 		a.height = msg.Height
+		a.clampSelections()
 		return a, nil
 
 	case pomodoroTickMsg:
+		// Tasks move between date-based lists at midnight without a reload.
+		a.clampSelections()
 		if a.pomo.tick() {
 			return a, tea.Batch(pomodoroTick(), notifyPhaseChange(a.pomo.phase))
 		}
@@ -233,7 +238,7 @@ var expandedAllowedKeys = map[string]bool{
 
 // updateSimple is the whole key map for --simple: one list, one selection,
 // and tab choosing which kind of item `a` will add. The other panes don't
-// exist here, so their bindings (pomodoro, filters, focus switching, layout)
+// exist here, so their bindings (pomodoro, focus switching, layout)
 // are simply absent rather than being gated off.
 func (a App) updateSimple(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	entries := a.simpleEntries()
@@ -242,7 +247,24 @@ func (a App) updateSimple(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "ctrl+c":
 		return a, tea.Quit
 
+	case "C":
+		a.toggleUpcoming()
+		return a, nil
+
+	case "I":
+		a.filterImportant = !a.filterImportant
+		a.clampSelections()
+		return a, nil
+
+	case "U":
+		a.filterUndone = !a.filterUndone
+		a.clampSelections()
+		return a, nil
+
 	case "tab":
+		if a.upcoming {
+			a.toggleUpcoming()
+		}
 		a.simpleNoteMode = !a.simpleNoteMode
 		return a, nil
 
@@ -275,10 +297,12 @@ func (a App) updateSimple(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		a.toggleTaskByID(e.task.ID)
+		a.clampSelections()
 		return a, nil
 
 	case "d":
 		if a.simpleSelected >= 0 && a.simpleSelected < len(entries) {
+			a.deleteItemID = a.selectedItemID()
 			a.mode = modeConfirmDelete
 		}
 		return a, nil
@@ -287,6 +311,7 @@ func (a App) updateSimple(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if a.simpleSelected >= 0 && a.simpleSelected < len(entries) {
 			if e := entries[a.simpleSelected]; !e.isNote {
 				a.toggleImportantByID(e.task.ID)
+				a.clampSelections()
 			}
 		}
 		return a, nil
@@ -335,6 +360,7 @@ func (a *App) syncSimpleScroll(entries []simpleEntry) {
 		}
 	}
 	if first < 0 {
+		a.simpleScroll = 0
 		return
 	}
 	scroll := a.simpleScroll
@@ -485,11 +511,13 @@ func (a App) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if a.focus == focusNotes {
 			if len(a.notes) > 0 {
+				a.deleteItemID = a.selectedItemID()
 				a.mode = modeConfirmDelete
 			}
 			return a, nil
 		}
-		if a.selectedTask() != nil {
+		if selected := a.selectedTask(); selected != nil {
+			a.deleteItemID = a.selectedItemID()
 			a.mode = modeConfirmDelete
 		}
 		return a, nil
@@ -497,8 +525,12 @@ func (a App) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "C":
 		// Clear the whole board. Capitalised and confirmed, since it discards
 		// everything at once.
-		if a.focus == focusNotes && len(a.notes) > 0 {
-			a.mode = modeConfirmClearNotes
+		if a.focus == focusNotes {
+			if len(a.notes) > 0 {
+				a.mode = modeConfirmClearNotes
+			}
+		} else {
+			a.toggleUpcoming()
 		}
 		return a, nil
 
@@ -574,8 +606,9 @@ func (a App) updateAdding(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.input.Blur()
 		return a, nil
 	case "enter":
-		a.addTask(a.input.Value())
-		a.input.SetValue("")
+		if a.addTask(a.input.Value()) {
+			a.input.SetValue("")
+		}
 		return a, nil
 	}
 
@@ -876,41 +909,31 @@ func (a *App) inputFieldWidth() int {
 	return w
 }
 
-func (a *App) addTask(raw string) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return
-	}
-
-	title := raw
-	taskTime := ""
-	kind := model.KindTask
-	fields := strings.Fields(raw)
-	if len(fields) > 0 {
-		last := fields[len(fields)-1]
-		if isTimeLike(last) {
-			taskTime = last
-			kind = model.KindAppointment
-			title = strings.TrimSpace(strings.TrimSuffix(raw, last))
-		}
-	}
-	if title == "" {
-		return
+func (a *App) addTask(raw string) bool {
+	now := a.now()
+	input, err := parseTaskInput(raw, now)
+	if err != nil {
+		a.err = err.Error()
+		return false
 	}
 
 	t := model.Task{
-		ID:        strconv.FormatInt(a.now().UnixNano(), 36),
-		Title:     title,
+		ID:        strconv.FormatInt(now.UnixNano(), 36),
+		Title:     input.Title,
 		Done:      false,
-		Kind:      kind,
-		Date:      a.now().Format(dateFormat),
-		Time:      taskTime,
-		CreatedAt: a.now(),
+		Kind:      input.Kind,
+		Date:      input.Date,
+		Time:      input.Time,
+		CreatedAt: now,
 	}
 
+	a.err = ""
 	a.tasks = append(a.tasks, t)
 	a.persist()
+	a.showTaskDate(t.Date)
 	a.selectTaskByID(t.ID)
+	a.status = "Added for " + t.Date
+	return true
 }
 
 // selectTaskByID moves the selection onto the task with the given ID and
@@ -931,7 +954,7 @@ func (a *App) selectTaskByID(id string) {
 		}
 		return
 	}
-	for i, t := range a.todayTasks() {
+	for i, t := range a.activeDayTasks() {
 		if t.ID == id {
 			a.todaySelected = i
 			// Selection only follows the cursor in the pane that owns it;
@@ -1050,7 +1073,13 @@ func (a App) notesContentWidth() int {
 }
 
 func (a *App) clampSelections() {
-	todayLen := len(a.todayTasks())
+	if a.simple {
+		entries := a.simpleEntries()
+		a.simpleSelected = max(0, min(a.simpleSelected, len(entries)-1))
+		a.syncSimpleScroll(entries)
+		return
+	}
+	todayLen := len(a.activeDayTasks())
 	if a.todaySelected >= todayLen {
 		a.todaySelected = todayLen - 1
 	}
@@ -1070,7 +1099,13 @@ func (a *App) clampSelections() {
 	if a.notesSelected < 0 {
 		a.notesSelected = 0
 	}
-	a.syncScroll()
+	// Both task panes stay valid even when another pane has focus.
+	focus := a.focus
+	for _, pane := range []focusedPane{focusToday, focusOverdue, focusNotes} {
+		a.focus = pane
+		a.syncScroll()
+	}
+	a.focus = focus
 }
 
 func (a *App) toggleSelected() {
@@ -1093,6 +1128,7 @@ func (a *App) toggleSelected() {
 		}
 	}
 	a.persist()
+	a.clampSelections()
 }
 
 func (a *App) toggleImportantSelected() {
@@ -1109,6 +1145,7 @@ func (a *App) toggleImportantSelected() {
 		}
 	}
 	a.persist()
+	a.clampSelections()
 }
 
 // saveSettings persists every user preference at once. Settings are written
@@ -1140,12 +1177,45 @@ func (a *App) selectedTask() *model.Task {
 	return &list[sel]
 }
 
+// selectedItemID pins a confirmation to its task or note, even when a date
+// change changes the visible list while the user is answering the prompt.
+func (a *App) selectedItemID() string {
+	if a.simple {
+		entries := a.simpleEntries()
+		if a.simpleSelected < 0 || a.simpleSelected >= len(entries) {
+			return ""
+		}
+		entry := entries[a.simpleSelected]
+		if entry.isNote {
+			return "note:" + entry.note.ID
+		}
+		return "task:" + entry.task.ID
+	}
+	if a.focus == focusNotes {
+		if a.notesSelected >= 0 && a.notesSelected < len(a.notes) {
+			return "note:" + a.notes[a.notesSelected].ID
+		}
+		return ""
+	}
+	if task := a.selectedTask(); task != nil {
+		return "task:" + task.ID
+	}
+	return ""
+}
+
 // updateConfirmDelete handles the y/n prompt shown before a delete. Anything
 // other than an explicit confirmation cancels, so a stray keypress can't
 // destroy a task.
 func (a App) updateConfirmDelete(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y", "enter":
+		if a.deleteItemID != "" && a.selectedItemID() != a.deleteItemID {
+			a.mode = modeNormal
+			a.deleteItemID = ""
+			a.status = "Item list changed; delete cancelled"
+			return a, nil
+		}
+		a.deleteItemID = ""
 		switch {
 		case a.simple:
 			a.deleteSimpleSelected()
@@ -1155,9 +1225,11 @@ func (a App) updateConfirmDelete(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a.deleteSelected()
 		}
 		a.mode = modeNormal
+		a.clampSelections()
 		return a, nil
 	default:
 		a.mode = modeNormal
+		a.deleteItemID = ""
 		a.status = "Delete cancelled"
 		return a, nil
 	}
@@ -1203,7 +1275,7 @@ func (a *App) persist() {
 func (a App) currentList() []model.Task {
 	switch a.focus {
 	case focusToday:
-		return a.todayTasks()
+		return a.activeDayTasks()
 	case focusOverdue:
 		return a.overdueTasks()
 	default:
@@ -1324,6 +1396,7 @@ func (a App) helpGroups() []helpGroup {
 			{"", []helpKey{
 				{"a", "add " + what}, {"tab", "switch to " + map[bool]string{true: "task", false: "note"}[a.simpleNoteMode]},
 				{"space/enter", "toggle/edit"}, {"d", "delete"}, {"i", "important"},
+				{"C", a.upcomingSwitchLabel()}, {"I/U", "filters"},
 				{"↑/↓ j/k", "navigate"}, {"t", "theme"}, {"q", "quit"},
 			}},
 		}
@@ -1352,7 +1425,7 @@ func (a App) helpGroups() []helpGroup {
 		return []helpGroup{
 			{"", []helpKey{
 				{"enter", "confirm"}, {"esc", "cancel"},
-				{"", "end with HH:MM to add it as an appointment"},
+				{"", "title [MM-DD] [HH:MM]"},
 			}},
 		}
 	}
@@ -1383,7 +1456,7 @@ func (a App) helpGroups() []helpGroup {
 			{"Chart", []helpKey{
 				{"←/→ h/l", "switch chart"}, {"", a.reportChart.String()},
 			}},
-			{"View", []helpKey{{"tab", "switch pane"}}},
+			{"View", []helpKey{{"tab", "switch pane"}, {"C", a.upcomingSwitchLabel()}}},
 			{"App", []helpKey{
 				{"t", "theme"}, {"S", "settings"}, {"L", "layout"}, {"q", "quit"},
 			}},
@@ -1403,7 +1476,7 @@ func (a App) helpGroups() []helpGroup {
 	return []helpGroup{
 		{"Task", taskKeys},
 		{"View", []helpKey{
-			{"tab", "switch pane"}, {"↑/↓ j/k", "navigate"}, {"I/U", "filters"},
+			{"tab", "switch pane"}, {"↑/↓ j/k", "navigate"}, {"C", a.upcomingSwitchLabel()}, {"I/U", "filters"},
 		}},
 		// Pomodoro's keys aren't listed here — they're rendered inside the
 		// Pomodoro pane itself, next to the thing they control.
@@ -1527,9 +1600,9 @@ func (a App) renderPage() string {
 
 	filters := filterLabel(a.filterImportant, a.filterUndone)
 
-	today := a.todayTasks()
+	today := a.activeDayTasks()
 	todayVisible := a.visibleRowsFor(focusToday)
-	todayBody := renderTaskList(today, a.todaySelected, a.todayScroll, todayVisible, a.focus == focusToday, false, leftWidth-4)
+	todayBody := renderTaskList(today, a.todaySelected, a.todayScroll, todayVisible, a.focus == focusToday, false, leftWidth-4, a.upcoming)
 	if a.mode == modeAdding {
 		// Set here rather than once in NewApp so these follow theme changes.
 		a.input.TextStyle = lipgloss.NewStyle().Foreground(colorText).Background(colorPaneBg)
@@ -1565,7 +1638,7 @@ func (a App) renderPage() string {
 		}
 		todayBody += "\n" + inputLine
 	}
-	todayPane := renderPane(fmt.Sprintf("Today (%d)%s", len(today), filters), todayBody, a.focus == focusToday, leftWidth, todayHeight)
+	todayPane := renderPane(fmt.Sprintf("%s (%d)%s", a.activeDayTitle(), len(today), filters), todayBody, a.focus == focusToday, leftWidth, todayHeight)
 
 	overdue := a.overdueTasks()
 	// In the stacked layout Today, Overdue and Notes share the row equally
@@ -1573,7 +1646,7 @@ func (a App) renderPage() string {
 	// Today and Overdue are stacked at the same width.
 	overdueWidth := leftWidth
 	overdueVisible := a.visibleRowsFor(focusOverdue)
-	overdueBody := renderTaskList(overdue, a.overdueSelected, a.overdueScroll, overdueVisible, a.focus == focusOverdue, true, overdueWidth-4)
+	overdueBody := renderTaskList(overdue, a.overdueSelected, a.overdueScroll, overdueVisible, a.focus == focusOverdue, true, overdueWidth-4, false)
 	overduePane := renderPane(fmt.Sprintf("Overdue (%d)%s", len(overdue), filters), overdueBody, a.focus == focusOverdue, overdueWidth, overdueHeight)
 
 	tasks := lipgloss.JoinVertical(lipgloss.Left, todayPane, overduePane)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -15,6 +15,7 @@ type keyMap struct {
 	Important      key.Binding
 	FilterImp      key.Binding
 	FilterUndone   key.Binding
+	Upcoming       key.Binding
 	PomodoroToggle key.Binding
 	PomodoroReset  key.Binding
 	PomodoroSkip   key.Binding
@@ -67,6 +68,10 @@ var keys = keyMap{
 	FilterUndone: key.NewBinding(
 		key.WithKeys("U"),
 		key.WithHelp("U", "filter undone"),
+	),
+	Upcoming: key.NewBinding(
+		key.WithKeys("C"),
+		key.WithHelp("C", "upcoming/today"),
 	),
 	PomodoroToggle: key.NewBinding(
 		key.WithKeys("p"),

--- a/internal/ui/schedule_add_test.go
+++ b/internal/ui/schedule_add_test.go
@@ -1,0 +1,97 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"taskii/internal/model"
+)
+
+func TestScheduledInputCreatesAndSelectsTask(t *testing.T) {
+	for _, simple := range []bool{false, true} {
+		t.Run(map[bool]string{false: "normal", true: "simple"}[simple], func(t *testing.T) {
+			a := NewApp(Options{Mock: true, Simple: simple})
+			a.tasks, a.notes = nil, nil
+			now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+			a.now = func() time.Time { return now }
+			a.width, a.height = 120, 40
+			a.mode = modeAdding
+			a.input.SetValue("Read a chapter 09-05")
+			updated, _ := a.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			a = updated.(App)
+			if len(a.tasks) != 1 {
+				t.Fatalf("created %d tasks, want 1", len(a.tasks))
+			}
+			task := a.tasks[0]
+			if task.Title != "Read a chapter" || task.Date != "2026-09-05" || task.Time != "" || task.Kind != model.KindTask {
+				t.Fatalf("unexpected scheduled task: %+v", task)
+			}
+			if !a.upcoming || len(a.todayTasks()) != 0 || a.input.Value() != "" {
+				t.Fatal("new future task must be visible in Upcoming and input cleared")
+			}
+			if simple {
+				entries := a.simpleEntries()
+				if len(entries) != 1 || entries[a.simpleSelected].task.ID != task.ID {
+					t.Fatal("simple selection did not follow scheduled task")
+				}
+			} else if selected := a.selectedTask(); selected == nil || selected.ID != task.ID {
+				t.Fatal("selection did not follow scheduled task")
+			}
+
+			// Continue the existing batch-add flow with a legacy appointment.
+			now = now.Add(time.Second)
+			a.input.SetValue("Call Alex 14:30")
+			updated, _ = a.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			a = updated.(App)
+			if len(a.tasks) != 2 || a.upcoming {
+				t.Fatal("legacy appointment must switch back to the current day")
+			}
+			if task = a.tasks[1]; task.Date != "2026-09-03" || task.Kind != model.KindAppointment || task.Time != "14:30" {
+				t.Fatalf("legacy appointment changed: %+v", task)
+			}
+		})
+	}
+}
+
+func TestInvalidScheduledInputCanBeCorrected(t *testing.T) {
+	a := NewApp(Options{Mock: true})
+	a.tasks = nil
+	a.now = func() time.Time { return time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC) }
+	a.width, a.height = 120, 40
+	a.mode = modeAdding
+	a.input.Focus()
+	const invalid = "Read 02-30"
+	a.input.SetValue(invalid)
+	updated, _ := a.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a = updated.(App)
+	if len(a.tasks) != 0 || a.input.Value() != invalid || a.err == "" || a.mode != modeAdding || !a.input.Focused() {
+		t.Fatal("invalid date must preserve the input and display an error")
+	}
+	a.input.SetValue("Read 09-05")
+	updated, _ = a.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	a = updated.(App)
+	if len(a.tasks) != 1 || a.input.Value() != "" || a.err != "" {
+		t.Fatal("corrected input must save once and clear the validation error")
+	}
+}
+
+func TestScheduledTaskPersistsExistingDateField(t *testing.T) {
+	t.Chdir(t.TempDir())
+	a := NewApp(Options{Mock: true})
+	a.tasks = nil
+	a.noPersist = false
+	a.now = func() time.Time { return time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC) }
+	a.width, a.height = 120, 40
+	if !a.addTask("Call Alex 09-05 14:30") || a.err != "" {
+		t.Fatalf("add failed: %s", a.err)
+	}
+	loaded, err := model.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 || loaded[0] != a.tasks[0] {
+		t.Fatalf("scheduled task did not survive reload: %+v", loaded)
+	}
+}

--- a/internal/ui/simple.go
+++ b/internal/ui/simple.go
@@ -28,10 +28,17 @@ type simpleEntry struct {
 // simpleEntries merges tasks and notes into one list ordered by creation time,
 // oldest first. Today's tasks, overdue tasks and notes all appear together.
 func (a App) simpleEntries() []simpleEntry {
+	if a.upcoming {
+		var out []simpleEntry
+		for _, t := range a.upcomingTasks() {
+			out = append(out, simpleEntry{created: t.CreatedAt, task: t})
+		}
+		return out
+	}
 	today := a.now().Format(dateFormat)
 	var out []simpleEntry
 
-	for _, t := range a.tasks {
+	for _, t := range a.applyFilters(a.tasks) {
 		// Today's items plus anything still undone from an earlier day —
 		// exactly the union of what the Today and Overdue panes show.
 		if t.Date != today && (t.Done || t.Date > today) {
@@ -170,7 +177,7 @@ func (a App) renderSimpleList(entries []simpleEntry, visibleRows, width int) str
 			lines = append(lines, line)
 			continue
 		}
-		lines = append(lines, renderTaskLine(e.task, selected, e.overdue, width, colorBg))
+		lines = append(lines, renderTaskLine(e.task, selected, e.overdue, width, colorBg, a.upcoming))
 	}
 
 	above := scroll
@@ -290,6 +297,9 @@ func (a App) renderSimpleTabs(width int) string {
 	}
 
 	row := tab("TASK", !a.simpleNoteMode) + gap.Render(" ") + tab("NOTE", a.simpleNoteMode)
+	if a.upcoming {
+		row = tab("Upcoming", true) + idleStyle.Render(filterLabel(a.filterImportant, a.filterUndone))
+	}
 	if pad := width - lipgloss.Width(row); pad > 0 {
 		row += gap.Render(strings.Repeat(" ", pad))
 	} else if pad < 0 {

--- a/internal/ui/task_input.go
+++ b/internal/ui/task_input.go
@@ -1,0 +1,91 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"taskii/internal/model"
+)
+
+type parsedTaskInput struct {
+	Title string
+	Date  string
+	Time  string
+	Kind  model.Kind
+}
+
+// parseTaskInput recognizes an optional MM-DD and trailing appointment time.
+// Dates without a year select their next occurrence, including today, using
+// now's local calendar date. The title retains its internal whitespace.
+func parseTaskInput(raw string, now time.Time) (parsedTaskInput, error) {
+	input := parsedTaskInput{
+		Title: strings.TrimSpace(raw),
+		Date:  now.Format(dateFormat),
+		Kind:  model.KindTask,
+	}
+	fields := strings.Fields(input.Title)
+	if len(fields) == 0 {
+		return parsedTaskInput{}, fmt.Errorf("task title cannot be empty")
+	}
+
+	last := fields[len(fields)-1]
+	if isTimeLike(last) {
+		input.Time = last
+		input.Kind = model.KindAppointment
+		input.Title = strings.TrimSpace(strings.TrimSuffix(input.Title, last))
+		fields = fields[:len(fields)-1]
+	} else if len(fields) >= 2 && isMonthDayToken(fields[len(fields)-2]) && len(last) == 5 && last[2] == ':' {
+		// Keep legacy time-like title text, but an explicitly scheduled
+		// appointment must not silently turn into an ordinary task.
+		return parsedTaskInput{}, fmt.Errorf("invalid appointment time %q: use HH:MM (00:00–23:59)", last)
+	}
+
+	if len(fields) > 0 {
+		last = fields[len(fields)-1]
+		if isMonthDayToken(last) {
+			date, err := nextScheduledDate(last, now)
+			if err != nil {
+				return parsedTaskInput{}, err
+			}
+			input.Date = date
+			input.Title = strings.TrimSpace(strings.TrimSuffix(input.Title, last))
+		}
+	}
+	if input.Title == "" {
+		return parsedTaskInput{}, fmt.Errorf("task title cannot be empty")
+	}
+	return input, nil
+}
+
+func isMonthDayToken(s string) bool {
+	if len(s) != 5 || s[2] != '-' {
+		return false
+	}
+	for _, i := range []int{0, 1, 3, 4} {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func nextScheduledDate(monthDay string, now time.Time) (string, error) {
+	// A leap year validates the month/day without rejecting February 29.
+	date, err := time.Parse(dateFormat, "2000-"+monthDay)
+	if err != nil {
+		return "", fmt.Errorf("invalid scheduled date %q: use a valid MM-DD", monthDay)
+	}
+	today := now.Format(dateFormat)
+	for year := now.Year(); ; year++ {
+		// Compare calendar dates, not instants; UTC avoids normalization of
+		// midnight in locations with daylight-saving transitions at midnight.
+		candidate := time.Date(year, date.Month(), date.Day(), 0, 0, 0, 0, time.UTC)
+		if candidate.Month() != date.Month() || candidate.Day() != date.Day() {
+			continue // February 29 in a non-leap year.
+		}
+		if scheduled := candidate.Format(dateFormat); scheduled >= today {
+			return scheduled, nil
+		}
+	}
+}

--- a/internal/ui/task_input_test.go
+++ b/internal/ui/task_input_test.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"taskii/internal/model"
+)
+
+func TestParseTaskInput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		now  string
+		want parsedTaskInput
+	}{
+		{"plain task", "Buy milk", "2026-09-03T12:00:00Z", parsedTaskInput{"Buy milk", "2026-09-03", "", model.KindTask}},
+		{"legacy appointment", "Meeting 14:30", "2026-09-03T12:00:00Z", parsedTaskInput{"Meeting", "2026-09-03", "14:30", model.KindAppointment}},
+		{"legacy invalid hour remains title", "Read 24:00", "2026-09-03T12:00:00Z", parsedTaskInput{"Read 24:00", "2026-09-03", "", model.KindTask}},
+		{"legacy invalid minute remains title", "Read 12:60", "2026-09-03T12:00:00Z", parsedTaskInput{"Read 12:60", "2026-09-03", "", model.KindTask}},
+		{"legacy short time remains title", "Read 9:30", "2026-09-03T12:00:00Z", parsedTaskInput{"Read 9:30", "2026-09-03", "", model.KindTask}},
+		{"legacy signed time accepted", "Read +1:00", "2026-09-03T12:00:00Z", parsedTaskInput{"Read", "2026-09-03", "+1:00", model.KindAppointment}},
+		{"date only", "Buy milk 09-05", "2026-09-03T12:00:00Z", parsedTaskInput{"Buy milk", "2026-09-05", "", model.KindTask}},
+		{"date and time", "Meeting 09-05 14:30", "2026-09-03T12:00:00Z", parsedTaskInput{"Meeting", "2026-09-05", "14:30", model.KindAppointment}},
+		{"same day allows earlier time", "Meeting 09-03 00:00", "2026-09-03T23:00:00Z", parsedTaskInput{"Meeting", "2026-09-03", "00:00", model.KindAppointment}},
+		{"previous date rolls year", "Meeting 09-02", "2026-09-03T12:00:00Z", parsedTaskInput{"Meeting", "2027-09-02", "", model.KindTask}},
+		{"new year", "Celebrate 01-01 00:00", "2026-12-31T23:59:00Z", parsedTaskInput{"Celebrate", "2027-01-01", "00:00", model.KindAppointment}},
+		{"leap day from common year", "Leap day 02-29", "2026-09-03T12:00:00Z", parsedTaskInput{"Leap day", "2028-02-29", "", model.KindTask}},
+		{"leap day today", "Leap day 02-29", "2028-02-29T23:59:00Z", parsedTaskInput{"Leap day", "2028-02-29", "", model.KindTask}},
+		{"past leap day", "Leap day 02-29", "2028-03-01T00:00:00Z", parsedTaskInput{"Leap day", "2032-02-29", "", model.KindTask}},
+		{"century leap gap", "Leap day 02-29", "2096-03-01T00:00:00Z", parsedTaskInput{"Leap day", "2104-02-29", "", model.KindTask}},
+		{"four hundred year leap", "Leap day 02-29", "2399-03-01T00:00:00Z", parsedTaskInput{"Leap day", "2400-02-29", "", model.KindTask}},
+		{"local day ahead of UTC", "Meeting 09-04", "2026-09-04T00:30:00+03:00", parsedTaskInput{"Meeting", "2026-09-04", "", model.KindTask}},
+		{"local day behind UTC", "Meeting 09-03", "2026-09-03T23:30:00-07:00", parsedTaskInput{"Meeting", "2026-09-03", "", model.KindTask}},
+		{"whitespace", "  Read  a\tbook \t09-05  14:30  ", "2026-09-03T12:00:00Z", parsedTaskInput{"Read  a\tbook", "2026-09-05", "14:30", model.KindAppointment}},
+		{"date within title", "Discuss 09-05 tomorrow", "2026-09-03T12:00:00Z", parsedTaskInput{"Discuss 09-05 tomorrow", "2026-09-03", "", model.KindTask}},
+		{"short date remains title", "Read 9-05", "2026-09-03T12:00:00Z", parsedTaskInput{"Read 9-05", "2026-09-03", "", model.KindTask}},
+		{"non ASCII date remains title", "Read ０９-０５", "2026-09-03T12:00:00Z", parsedTaskInput{"Read ０９-０５", "2026-09-03", "", model.KindTask}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now, err := time.Parse(time.RFC3339, tt.now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := parseTaskInput(tt.raw, now)
+			if err != nil {
+				t.Fatalf("parseTaskInput() error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseTaskInput() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTaskInputInvalid(t *testing.T) {
+	now := time.Date(2026, time.September, 3, 12, 0, 0, 0, time.UTC)
+	for _, raw := range []string{
+		"", " \t ", "14:30", "09-05", "09-05 14:30",
+		"Read 00-01", "Read 13-01", "Read 01-00", "Read 01-32",
+		"Read 02-30", "Read 04-31", "Read 02-30 14:30",
+		"Read 09-05 24:00", "Read 09-05 12:60", "Read 09-05 xx:yy",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			if got, err := parseTaskInput(raw, now); err == nil {
+				t.Errorf("parseTaskInput(%q) = %#v, expected error", raw, got)
+			}
+		})
+	}
+}

--- a/internal/ui/today.go
+++ b/internal/ui/today.go
@@ -14,7 +14,7 @@ import (
 // for the scroll indicator, so pane height stays constant whether or not the
 // indicator is actually shown). scrollOffset is the index of the first
 // visible task.
-func renderTaskList(tasks []model.Task, selected int, scrollOffset int, visibleRows int, focused bool, overdue bool, width int) string {
+func renderTaskList(tasks []model.Task, selected int, scrollOffset int, visibleRows int, focused bool, overdue bool, width int, showDate bool) string {
 	if len(tasks) == 0 {
 		// Blank second line matches the indicator line always emitted below,
 		// so an empty list is the same height as a populated one.
@@ -25,6 +25,7 @@ func renderTaskList(tasks []model.Task, selected int, scrollOffset int, visibleR
 		visibleRows = 1
 	}
 
+	scrollOffset = max(0, min(scrollOffset, len(tasks)-1))
 	end := scrollOffset + visibleRows
 	if end > len(tasks) {
 		end = len(tasks)
@@ -32,7 +33,7 @@ func renderTaskList(tasks []model.Task, selected int, scrollOffset int, visibleR
 
 	var lines []string
 	for i := scrollOffset; i < end; i++ {
-		lines = append(lines, renderTaskLine(tasks[i], i == selected && focused, overdue, width, colorPaneBg))
+		lines = append(lines, renderTaskLine(tasks[i], i == selected && focused, overdue, width, colorPaneBg, showDate))
 	}
 
 	// Always emit the indicator line, blank when unneeded, so the list's
@@ -54,7 +55,7 @@ func renderTaskList(tasks []model.Task, selected int, scrollOffset int, visibleR
 	return strings.Join(lines, "\n")
 }
 
-func renderTaskLine(t model.Task, selected bool, overdue bool, width int, surface lipgloss.Color) string {
+func renderTaskLine(t model.Task, selected bool, overdue bool, width int, surface lipgloss.Color, showDate bool) string {
 	openBracket, closeBracket := "[", "]"
 	if t.IsAppointment() {
 		openBracket, closeBracket = "{", "}"
@@ -114,6 +115,9 @@ func renderTaskLine(t model.Task, selected bool, overdue bool, width int, surfac
 	if t.Time != "" {
 		timePlain = t.Time
 	}
+	if showDate {
+		timePlain = strings.TrimSpace(t.Date + " " + timePlain)
+	}
 	starPlain := ""
 	if t.Important {
 		starPlain = "★"
@@ -143,7 +147,11 @@ func renderTaskLine(t model.Task, selected bool, overdue bool, width int, surfac
 		}
 	}
 
-	return b.String()
+	line := b.String()
+	if width > 0 && lipgloss.Width(line) > width {
+		return truncateANSI(line, width)
+	}
+	return line
 }
 
 // fitSegmentsToWidth measures the plain (unstyled) assembled line and, if it

--- a/internal/ui/upcoming.go
+++ b/internal/ui/upcoming.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"sort"
+
+	"taskii/internal/model"
+)
+
+// upcomingTasks projects future dates without moving or rewriting stored tasks.
+// ISO dates sort chronologically; appointments precede untimed tasks per day.
+func (a App) upcomingTasks() []model.Task {
+	today := a.now().Format(dateFormat)
+	var out []model.Task
+	for _, task := range a.tasks {
+		if task.Date > today {
+			out = append(out, task)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		left, right := out[i], out[j]
+		if left.Date != right.Date {
+			return left.Date < right.Date
+		}
+		if left.Time == right.Time {
+			return left.CreatedAt.Before(right.CreatedAt)
+		}
+		if left.Time == "" {
+			return false
+		}
+		if right.Time == "" {
+			return true
+		}
+		return left.Time < right.Time
+	})
+	return a.applyFilters(out)
+}
+
+func (a App) activeDayTasks() []model.Task {
+	if a.upcoming {
+		return a.upcomingTasks()
+	}
+	return a.todayTasks()
+}
+
+func (a App) activeDayTitle() string {
+	if a.upcoming {
+		return "Upcoming"
+	}
+	return "Today"
+}
+
+func (a App) upcomingSwitchLabel() string {
+	if a.upcoming {
+		if a.simple {
+			return "current"
+		}
+		return "today"
+	}
+	return "upcoming"
+}
+
+func (a *App) toggleUpcoming() {
+	a.setUpcoming(!a.upcoming)
+}
+
+func (a *App) setUpcoming(upcoming bool) {
+	a.upcoming = upcoming
+	a.todaySelected, a.todayScroll = 0, 0
+	a.simpleSelected, a.simpleScroll = 0, 0
+	if a.simple && upcoming {
+		// Upcoming contains tasks only. Tab returns to the mixed list before
+		// selecting note input, so a newly added note is always visible.
+		a.simpleNoteMode = false
+	}
+	if !a.simple {
+		a.focus = focusToday
+	}
+	a.clampSelections()
+}
+
+// showTaskDate selects the view that contains an added task. The caller then
+// selects its ID, because both daily and future lists have their own ordering.
+func (a *App) showTaskDate(date string) {
+	a.setUpcoming(date > a.now().Format(dateFormat))
+}

--- a/internal/ui/upcoming_test.go
+++ b/internal/ui/upcoming_test.go
@@ -1,0 +1,242 @@
+package ui
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"taskii/internal/model"
+)
+
+func upcomingTestApp() App {
+	a := NewApp(Options{Mock: true})
+	a.now = func() time.Time { return time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC) }
+	a.tasks = nil
+	a.notes = nil
+	a.width, a.height = 160, 45
+	return a
+}
+
+func upcomingKey(a App, key string) App {
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+	if key == "tab" {
+		msg = tea.KeyMsg{Type: tea.KeyTab}
+	}
+	updated, _ := a.Update(msg)
+	return updated.(App)
+}
+
+func upcomingIDs(tasks []model.Task) []string {
+	ids := make([]string, len(tasks))
+	for i, task := range tasks {
+		ids[i] = task.ID
+	}
+	return ids
+}
+
+func TestUpcomingDatesOrderingAndFilters(t *testing.T) {
+	a := upcomingTestApp()
+	created := a.now()
+	a.tasks = []model.Task{
+		{ID: "later", Date: "2027-01-01", CreatedAt: created},
+		{ID: "untimed-new", Date: "2026-09-04", CreatedAt: created.Add(time.Minute)},
+		{ID: "afternoon", Date: "2026-09-04", Time: "15:00", Kind: model.KindAppointment, CreatedAt: created},
+		{ID: "today", Date: "2026-09-03", CreatedAt: created},
+		{ID: "missed", Date: "2026-09-02", CreatedAt: created},
+		{ID: "morning", Date: "2026-09-04", Time: "08:00", Kind: model.KindAppointment, Important: true, CreatedAt: created},
+		{ID: "untimed-old", Date: "2026-09-04", Important: true, CreatedAt: created},
+		{ID: "done", Date: "2026-09-04", Done: true, Important: true, CreatedAt: created.Add(time.Hour)},
+	}
+	want := []string{"morning", "afternoon", "untimed-old", "untimed-new", "done", "later"}
+	if got := upcomingIDs(a.upcomingTasks()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("upcoming order = %v, want %v", got, want)
+	}
+	a.upcoming = true
+	if got := upcomingIDs(a.todayTasks()); !reflect.DeepEqual(got, []string{"today"}) {
+		t.Fatalf("Upcoming contaminated today's projection: %v", got)
+	}
+	if got := upcomingIDs(a.overdueTasks()); !reflect.DeepEqual(got, []string{"missed"}) {
+		t.Fatalf("overdue projection = %v", got)
+	}
+	a.filterImportant, a.filterUndone = true, true
+	if got := upcomingIDs(a.upcomingTasks()); !reflect.DeepEqual(got, []string{"morning", "untimed-old"}) {
+		t.Fatalf("combined filters = %v", got)
+	}
+}
+
+func TestUpcomingActionsTargetVisibleTasks(t *testing.T) {
+	for _, simple := range []bool{false, true} {
+		t.Run(fmt.Sprintf("simple=%v", simple), func(t *testing.T) {
+			a := upcomingTestApp()
+			a.simple = simple
+			a.tasks = []model.Task{
+				{ID: "today", Date: "2026-09-03"},
+				{ID: "future", Date: "2026-09-04"},
+			}
+			a = upcomingKey(a, "C")
+			a = upcomingKey(a, "i")
+			if a.tasks[0].Important || !a.tasks[1].Important {
+				t.Fatal("importance action targeted an invisible task")
+			}
+			a = upcomingKey(a, " ")
+			if a.tasks[0].Done || !a.tasks[1].Done || a.tasks[1].DoneAt == nil {
+				t.Fatal("completion action targeted an invisible task")
+			}
+			a = upcomingKey(a, "U")
+			a = upcomingKey(a, "d")
+			if a.mode != modeNormal {
+				t.Fatal("empty filtered view allowed a delete")
+			}
+			a = upcomingKey(a, "U")
+			a = upcomingKey(a, "d")
+			a = upcomingKey(a, "y")
+			if got := upcomingIDs(a.tasks); !reflect.DeepEqual(got, []string{"today"}) {
+				t.Fatalf("delete retained tasks %v", got)
+			}
+			if a.todaySelected != 0 || a.todayScroll != 0 || a.simpleSelected != 0 || a.simpleScroll != 0 {
+				t.Fatal("empty view has stale selection or scroll")
+			}
+		})
+	}
+}
+
+func TestUpcomingKeyPreservesNotesClearAndSimpleTabs(t *testing.T) {
+	a := upcomingTestApp()
+	a.focus = focusNotes
+	a.notes = []model.Note{{Body: "keep me"}}
+	a = upcomingKey(a, "C")
+	if a.mode != modeConfirmClearNotes || a.upcoming {
+		t.Fatal("C on Notes should still ask to clear the board")
+	}
+	a = upcomingTestApp()
+	a.simple, a.simpleNoteMode = true, true
+	a.notes = []model.Note{{Body: "note"}}
+	a.tasks = []model.Task{{ID: "today", Date: "2026-09-03"}, {ID: "future", Date: "2026-09-04"}}
+	a = upcomingKey(a, "C")
+	if !a.upcoming || a.simpleNoteMode || len(a.simpleEntries()) != 1 || a.simpleEntries()[0].isNote {
+		t.Fatal("simple Upcoming should expose only future tasks and task input")
+	}
+	a = upcomingKey(a, "tab")
+	if a.upcoming || !a.simpleNoteMode || len(a.simpleEntries()) != 2 {
+		t.Fatal("tab should return to the combined list before choosing note input")
+	}
+	a = upcomingKey(a, "C")
+	a = upcomingKey(a, "C")
+	if a.upcoming || len(a.simpleEntries()) != 2 {
+		t.Fatal("C should restore the combined list")
+	}
+}
+
+func TestUpcomingMidnightRolloverAndPendingDelete(t *testing.T) {
+	for _, simple := range []bool{false, true} {
+		t.Run(fmt.Sprintf("simple=%v", simple), func(t *testing.T) {
+			a := upcomingTestApp()
+			a.simple = simple
+			now := a.now()
+			a.now = func() time.Time { return now }
+			a.tasks = []model.Task{
+				{ID: "due", Date: "2026-09-04"},
+				{ID: "future", Date: "2026-09-05"},
+			}
+			a = upcomingKey(a, "C")
+			a = upcomingKey(a, "d")
+			now = now.AddDate(0, 0, 1)
+			updated, _ := a.Update(pomodoroTickMsg(now))
+			a = updated.(App)
+			if got := upcomingIDs(a.todayTasks()); !reflect.DeepEqual(got, []string{"due"}) {
+				t.Fatalf("task did not become due: %v", got)
+			}
+			a = upcomingKey(a, "y")
+			if len(a.tasks) != 2 || a.mode != modeNormal {
+				t.Fatal("rollover deleted a different task from the confirmed one")
+			}
+			a.todaySelected, a.todayScroll = 99, 99
+			a.simpleSelected, a.simpleScroll = 99, 99
+			now = now.AddDate(0, 0, 2)
+			updated, _ = a.Update(pomodoroTickMsg(now))
+			a = updated.(App)
+			if simple {
+				if a.simpleSelected != 0 || a.simpleScroll != 0 {
+					t.Fatal("simple selection did not recover from an empty future list")
+				}
+			} else if a.todaySelected != 0 || a.todayScroll != 0 {
+				t.Fatal("pane selection did not recover from an empty future list")
+			}
+			if len(a.overdueTasks()) != 2 {
+				t.Fatal("missed scheduled tasks should use existing overdue behavior")
+			}
+		})
+	}
+}
+
+func TestUpcomingDateRenderingAndDimensions(t *testing.T) {
+	task := model.Task{ID: "future", Title: "A long scheduled task with a wide character 界", Date: "2026-09-04", Time: "09:30", Kind: model.KindAppointment}
+	line := renderTaskLine(task, true, false, 60, colorPaneBg, true)
+	if !strings.Contains(line, "2026-09-04 09:30") || task.Time != "09:30" {
+		t.Fatal("date and appointment time should render together without changing Task.Time")
+	}
+	for _, width := range []int{12, 20, 30, 60} {
+		if got := lipgloss.Width(renderTaskLine(task, true, false, width, colorPaneBg, true)); got > width {
+			t.Fatalf("row width %d exceeds budget %d", got, width)
+		}
+	}
+	for _, simple := range []bool{false, true} {
+		for _, lay := range []layout{layoutTasksLeft, layoutTasksRight, layoutStacked, layoutThreeColumn} {
+			for _, size := range [][2]int{{100, 30}, {160, 45}} {
+				t.Run(fmt.Sprintf("simple=%v/%s/%dx%d", simple, lay, size[0], size[1]), func(t *testing.T) {
+					a := upcomingTestApp()
+					a.simple, a.layout = simple, lay
+					a.width, a.height = size[0], size[1]
+					a.tasks = []model.Task{task}
+					a = upcomingKey(a, "C")
+					page := a.View()
+					if !strings.Contains(page, "Upcoming") || !strings.Contains(page, "2026-09-04") {
+						t.Fatal("Upcoming title or scheduled date missing")
+					}
+					if lipgloss.Width(page) > a.width || lipgloss.Height(page) > a.height {
+						t.Fatalf("view %dx%d exceeds terminal %dx%d", lipgloss.Width(page), lipgloss.Height(page), a.width, a.height)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestShowTaskDateSelectsAddedTaskView(t *testing.T) {
+	for _, simple := range []bool{false, true} {
+		a := upcomingTestApp()
+		a.simple = simple
+		a.tasks = []model.Task{{ID: "today", Date: "2026-09-03"}, {ID: "future", Date: "2026-09-04"}}
+		a.showTaskDate("2026-09-04")
+		a.selectTaskByID("future")
+		if !a.upcoming {
+			t.Fatal("adding a scheduled task should show Upcoming")
+		}
+		a.showTaskDate("2026-09-03")
+		a.selectTaskByID("today")
+		if a.upcoming {
+			t.Fatal("adding a task today should restore the current-day view")
+		}
+	}
+}
+
+func TestUpcomingRolloverDoesNotRetargetSimpleNoteDeletion(t *testing.T) {
+	a := upcomingTestApp()
+	a.simple = true
+	now := a.now()
+	a.now = func() time.Time { return now }
+	a.tasks = []model.Task{{ID: "newly-due", Date: "2026-09-04", CreatedAt: now.Add(-time.Hour)}}
+	a.notes = []model.Note{{ID: "note", Body: "keep this note", CreatedAt: now}}
+	a = upcomingKey(a, "d")
+	now = now.AddDate(0, 0, 1)
+	updated, _ := a.Update(pomodoroTickMsg(now))
+	a = upcomingKey(updated.(App), "y")
+	if len(a.tasks) != 1 || len(a.notes) != 1 || a.mode != modeNormal {
+		t.Fatal("newly due task changed the target of a note deletion confirmation")
+	}
+}


### PR DESCRIPTION
## Summary

add support for scheduling tasks and appointments for future dates, with an upcoming view (`ctrl + c`) available in both modes (simple and normal)

## Changes
* extend task input with an optional `MM-DD` date format. for examples:
  * `read a chapter 09-10` creates a task for September 10.
  * `team meeting 09-10 14:30` creates an appointment for that date and time.
* preserve the existing `title HH:MM` syntax for today's appointments.
* `Shift+C` to switch between the current view and upcoming. (still notes pane's clear-board shortcut)
* show scheduled dates and sort upcoming items by date and appointment time.
* store the scheduled day in the existing `Task.Date` field. the json format is the same.
* updated docs and add some tests

## Behavior

dates without a year resolve to their next occurrence, including today. Invalid dates show an error and preserve the input for correction.

scheduled tasks appear in Today on their date. Unfinished tasks keep following the current overdue behavior. lists refresh while the application is running.
